### PR TITLE
4️⃣주차 과제 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ## .DS_Store
 .DS_Store
 
+Secret/
 
 ## User settings
 xcuserdata/

--- a/TVING/TVING.xcodeproj/project.pbxproj
+++ b/TVING/TVING.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DD00757D2BED63FA00178F78 /* WeeklyResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00757C2BED63FA00178F78 /* WeeklyResponseModel.swift */; };
+		DD0075822BED669500178F78 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = DD0075812BED669500178F78 /* Moya */; };
+		DD0075852BED683900178F78 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0075842BED683900178F78 /* Secret.swift */; };
+		DD0075882BED6B8A00178F78 /* WeeklyBoxOfficeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0075872BED6B8A00178F78 /* WeeklyBoxOfficeAPI.swift */; };
 		DD02DB7C2BCE627A008ACD16 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD02DB7B2BCE627A008ACD16 /* AppDelegate.swift */; };
 		DD02DB7E2BCE627A008ACD16 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD02DB7D2BCE627A008ACD16 /* SceneDelegate.swift */; };
 		DD02DB802BCE627A008ACD16 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD02DB7F2BCE627A008ACD16 /* LoginViewController.swift */; };
@@ -37,6 +41,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		DD00757C2BED63FA00178F78 /* WeeklyResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyResponseModel.swift; sourceTree = "<group>"; };
+		DD0075842BED683900178F78 /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
+		DD0075872BED6B8A00178F78 /* WeeklyBoxOfficeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyBoxOfficeAPI.swift; sourceTree = "<group>"; };
 		DD02DB782BCE627A008ACD16 /* TVING.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TVING.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD02DB7B2BCE627A008ACD16 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DD02DB7D2BCE627A008ACD16 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -73,12 +80,29 @@
 			files = (
 				DD02DB912BCE62B1008ACD16 /* SnapKit in Frameworks */,
 				DD02DB942BCE62BC008ACD16 /* Then in Frameworks */,
+				DD0075822BED669500178F78 /* Moya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		DD0075832BED682F00178F78 /* Secret */ = {
+			isa = PBXGroup;
+			children = (
+				DD0075842BED683900178F78 /* Secret.swift */,
+			);
+			path = Secret;
+			sourceTree = "<group>";
+		};
+		DD0075862BED690A00178F78 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				DD0075872BED6B8A00178F78 /* WeeklyBoxOfficeAPI.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 		DD02DB6F2BCE627A008ACD16 = {
 			isa = PBXGroup;
 			children = (
@@ -149,7 +173,6 @@
 				DD02DB862BCE627B008ACD16 /* LaunchScreen.storyboard */,
 				DDEB19A72BE0C050009A2F79 /* Model */,
 				DD44E4532BD91AB800258D29 /* ViewController */,
-				DDEB19A62BE0B864009A2F79 /* View */,
 				DDEB199F2BE0AFBF009A2F79 /* Cell */,
 			);
 			path = Source;
@@ -158,6 +181,8 @@
 		DD44E4552BD91AE700258D29 /* Resource */ = {
 			isa = PBXGroup;
 			children = (
+				DD0075862BED690A00178F78 /* Network */,
+				DD0075832BED682F00178F78 /* Secret */,
 				DD02DBA82BCE640A008ACD16 /* Extension */,
 				DD02DB952BCE6404008ACD16 /* Fonts */,
 				DD02DB842BCE627B008ACD16 /* Assets.xcassets */,
@@ -176,18 +201,12 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
-		DDEB19A62BE0B864009A2F79 /* View */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
 		DDEB19A72BE0C050009A2F79 /* Model */ = {
 			isa = PBXGroup;
 			children = (
 				DDEB19A82BE0C064009A2F79 /* Content.swift */,
 				DDEB19AC2BE0C0C3009A2F79 /* Channel.swift */,
+				DD00757C2BED63FA00178F78 /* WeeklyResponseModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -211,6 +230,7 @@
 			packageProductDependencies = (
 				DD02DB902BCE62B1008ACD16 /* SnapKit */,
 				DD02DB932BCE62BC008ACD16 /* Then */,
+				DD0075812BED669500178F78 /* Moya */,
 			);
 			productName = TVING;
 			productReference = DD02DB782BCE627A008ACD16 /* TVING.app */;
@@ -243,6 +263,7 @@
 			packageReferences = (
 				DD02DB8F2BCE62B1008ACD16 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				DD02DB922BCE62BC008ACD16 /* XCRemoteSwiftPackageReference "Then" */,
+				DD0075802BED669500178F78 /* XCRemoteSwiftPackageReference "Moya" */,
 			);
 			productRefGroup = DD02DB792BCE627A008ACD16 /* Products */;
 			projectDirPath = "";
@@ -285,11 +306,14 @@
 				DDEB19A32BE0B16C009A2F79 /* UIColor+.swift in Sources */,
 				DD31670C2BE12C6900F8CEE2 /* SegmentCollectionViewCell.swift in Sources */,
 				DDEB19A12BE0B01B009A2F79 /* ContentCollectionViewCell.swift in Sources */,
+				DD00757D2BED63FA00178F78 /* WeeklyResponseModel.swift in Sources */,
 				DDEB19A52BE0B463009A2F79 /* ChannelCollectionViewCell.swift in Sources */,
 				DDEB19AD2BE0C0C3009A2F79 /* Channel.swift in Sources */,
 				DDEB19A92BE0C064009A2F79 /* Content.swift in Sources */,
+				DD0075852BED683900178F78 /* Secret.swift in Sources */,
 				DD02DB802BCE627A008ACD16 /* LoginViewController.swift in Sources */,
 				DD02DBB02BCE9564008ACD16 /* UIControl+.swift in Sources */,
+				DD0075882BED6B8A00178F78 /* WeeklyBoxOfficeAPI.swift in Sources */,
 				DD02DB7C2BCE627A008ACD16 /* AppDelegate.swift in Sources */,
 				DD02DB7E2BCE627A008ACD16 /* SceneDelegate.swift in Sources */,
 				DD44E4582BD93AF900258D29 /* MainViewController.swift in Sources */,
@@ -509,6 +533,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		DD0075802BED669500178F78 /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 15.0.3;
+			};
+		};
 		DD02DB8F2BCE62B1008ACD16 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -528,6 +560,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		DD0075812BED669500178F78 /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DD0075802BED669500178F78 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
 		DD02DB902BCE62B1008ACD16 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = DD02DB8F2BCE62B1008ACD16 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/TVING/TVING.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TVING/TVING.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,42 @@
 {
+  "originHash" : "fc8f8614896aa5ec8688d98e70bf3791328287c9bb560963e7f53aaaf1a62dca",
   "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya",
+      "state" : {
+        "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
+        "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
+        "version" : "6.7.1"
+      }
+    },
     {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
@@ -19,5 +56,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/TVING/TVING/Resource/Info.plist
+++ b/TVING/TVING/Resource/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>

--- a/TVING/TVING/Resource/Network/WeeklyBoxOfficeAPI.swift
+++ b/TVING/TVING/Resource/Network/WeeklyBoxOfficeAPI.swift
@@ -1,0 +1,54 @@
+//
+//  WeeklyBoxOfficeAPI.swift
+//  TVING
+//
+//  Created by YOUJIM on 5/10/24.
+//
+
+import Foundation
+
+import Moya
+
+enum WeeklyBoxOfficeAPI {
+    case weekly
+}
+
+
+extension WeeklyBoxOfficeAPI: TargetType {
+    var path: String {
+        return "/kobisopenapi/webservice/rest/boxoffice/searchWeeklyBoxOfficeList.json"
+    }
+    
+    var method: Moya.Method {
+        return .get
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .weekly:
+            let parameter: [String: String] = [
+                "key": Secret.movieAPIkey,
+                "targetDt": "20240503",
+                "weekGb": "0",
+                "itemPerPage": "10",
+                "multiMovieYn": "",
+                "repNationCd": "",
+                "wideAreaCd": ""
+            ]
+            
+            return .requestParameters(parameters: parameter, encoding: URLEncoding.queryString)
+            
+        default:
+            return .requestPlain
+        }
+        
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+    
+    var baseURL: URL {
+        return URL(string: "http://www.kobis.or.kr")!
+    }
+}

--- a/TVING/TVING/Source/AppDelegate.swift
+++ b/TVING/TVING/Source/AppDelegate.swift
@@ -10,8 +10,6 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
@@ -30,7 +28,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
 

--- a/TVING/TVING/Source/Model/WeeklyResponseModel.swift
+++ b/TVING/TVING/Source/Model/WeeklyResponseModel.swift
@@ -1,0 +1,25 @@
+//
+//  WeeklyResponseModel.swift
+//  TVING
+//
+//  Created by YOUJIM on 5/10/24.
+//
+
+import Foundation
+
+
+struct WeeklyResponseModel: Codable {
+    let boxOfficeResult: boxOfficeResult
+}
+
+struct boxOfficeResult: Codable {
+    let boxofficeType, showRange, yearWeekTime: String
+    let weeklyBoxOfficeList: [WeeklyBoxOfficeList]
+}
+
+struct WeeklyBoxOfficeList: Codable {
+    let rnum, rank, rankInten, rankOldAndNew, movieCd, movieNm, openDt, salesAmt,
+    salesShare, salesInten, salesChange, salesAcc, audiCnt, audiInten, audiChange, audiAcc,
+    scrnCnt, showCnt: String
+}
+

--- a/TVING/TVING/Source/ViewController/MainViewController.swift
+++ b/TVING/TVING/Source/ViewController/MainViewController.swift
@@ -7,39 +7,43 @@
 
 import UIKit
 
-class MainViewController: UIViewController {
+import SnapKit
+import Then
+import Moya
+
+final class MainViewController: UIViewController {
     
     
     // MARK: - Data
     
-    let contentDummy = Content.dummy()
+    var contentData = [Content]()
     let channelDummy = Channel.dummy()
     let segmentData = ["홈", "실시간", "TV프로그램", "영화", "파라마운트+"]
     
     
     // MARK: - Component
     
-    final private let scrollView = UIScrollView().then {
+    private let scrollView = UIScrollView().then {
         $0.backgroundColor = .black
     }
     
-    final private let contentView = UIView()
+    private let contentView = UIView()
     
-    final private let logoImageView: UIImageView = UIImageView().then {
+    private let logoImageView: UIImageView = UIImageView().then {
         $0.image = .mainLogo
         $0.contentMode = .scaleAspectFit
     }
     
-    final private let mirroringButton: UIButton = UIButton().then {
+    private let mirroringButton: UIButton = UIButton().then {
         $0.setImage(.icMirroring, for: .normal)
     }
     
-    final private let profileImageView: UIImageView = UIImageView().then {
+    private let profileImageView: UIImageView = UIImageView().then {
         $0.image = .basicProfile
         $0.contentMode = .scaleToFill
     }
     
-    final private let segmentCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
+    private let segmentCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
         $0.scrollDirection = .horizontal
         $0.minimumLineSpacing = 32
         $0.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
@@ -49,18 +53,18 @@ class MainViewController: UIViewController {
         $0.register(SegmentCollectionViewCell.self, forCellWithReuseIdentifier: SegmentCollectionViewCell.cellID)
     }
     
-    final private let mainPosterView: UIImageView = UIImageView().then {
+    private let mainPosterView: UIImageView = UIImageView().then {
         $0.image = .mainPoster
         $0.contentMode = .scaleAspectFill
     }
     
-    final private let contentLabel: UILabel = UILabel().then {
+    private let contentLabel: UILabel = UILabel().then {
         $0.font = UIFont.font(.applegothicSemibold, ofSize: 15)
         $0.textColor = .white
         $0.text = "티빙에서 꼭 봐야하는 컨텐츠"
     }
     
-    final private lazy var moreContentButton: UIButton = UIButton().then {
+    private lazy var moreContentButton: UIButton = UIButton().then {
         $0.setTitle("전체보기", for: .normal)
         $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
         $0.tintColor = .white
@@ -70,7 +74,7 @@ class MainViewController: UIViewController {
         $0.semanticContentAttribute = .forceRightToLeft
     }
     
-    final private lazy var contentCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
+    private lazy var contentCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
         $0.scrollDirection = .horizontal
         $0.minimumLineSpacing = 10
         $0.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
@@ -80,13 +84,13 @@ class MainViewController: UIViewController {
         $0.register(ContentCollectionViewCell.self, forCellWithReuseIdentifier: ContentCollectionViewCell.cellID)
     }
     
-    final private let channelLabel: UILabel = UILabel().then {
+    private let channelLabel: UILabel = UILabel().then {
         $0.font = UIFont.font(.applegothicSemibold, ofSize: 15)
         $0.textColor = .white
         $0.text = "인기 LIVE 채널"
     }
     
-    final private lazy var moreChannelButton: UIButton = UIButton().then {
+    private lazy var moreChannelButton: UIButton = UIButton().then {
         $0.setTitle("전체보기", for: .normal)
         $0.tintColor = .white
         $0.setTitleColor(UIColor(hexCode: "9C9C9C"), for: .normal)
@@ -96,7 +100,7 @@ class MainViewController: UIViewController {
         $0.semanticContentAttribute = .forceRightToLeft
     }
     
-    final private lazy var channelCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
+    private lazy var channelCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
         $0.scrollDirection = .horizontal
         $0.minimumLineSpacing = 10
         $0.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
@@ -106,13 +110,13 @@ class MainViewController: UIViewController {
         $0.register(ChannelCollectionViewCell.self, forCellWithReuseIdentifier: ChannelCollectionViewCell.cellID)
     }
     
-    final private let seriesLabel: UILabel = UILabel().then {
+    private let seriesLabel: UILabel = UILabel().then {
         $0.font = UIFont.font(.applegothicSemibold, ofSize: 15)
         $0.textColor = .white
         $0.text = "1화 무료! 파라마운트+ 인기 시리즈"
     }
     
-    final private lazy var moreSeriesButton: UIButton = UIButton().then {
+    private lazy var moreSeriesButton: UIButton = UIButton().then {
         $0.setTitle("전체보기", for: .normal)
         $0.tintColor = .white
         $0.setTitleColor(UIColor(hexCode: "9C9C9C"), for: .normal)
@@ -122,7 +126,7 @@ class MainViewController: UIViewController {
         $0.semanticContentAttribute = .forceRightToLeft
     }
     
-    final private lazy var seriesCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
+    private lazy var seriesCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
         $0.scrollDirection = .horizontal
         $0.minimumLineSpacing = 10
         $0.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
@@ -132,23 +136,23 @@ class MainViewController: UIViewController {
         $0.register(ContentCollectionViewCell.self, forCellWithReuseIdentifier: ContentCollectionViewCell.cellID)
     }
     
-    final private let firstAdImageView: UIImageView = UIImageView().then {
+    private let firstAdImageView: UIImageView = UIImageView().then {
         $0.image = .firstAD
         $0.contentMode = .scaleAspectFill
     }
     
-    final private let secondAdImageView: UIImageView = UIImageView().then {
+    private let secondAdImageView: UIImageView = UIImageView().then {
         $0.image = .secondAD
         $0.contentMode = .scaleAspectFill
     }
     
-    final private let movieLabel: UILabel = UILabel().then {
+    private let movieLabel: UILabel = UILabel().then {
         $0.font = UIFont.font(.applegothicSemibold, ofSize: 15)
         $0.textColor = .white
         $0.text = "티빙에서 꼭 봐야하는 컨텐츠"
     }
     
-    final private lazy var moreMovieButton: UIButton = UIButton().then {
+    private lazy var moreMovieButton: UIButton = UIButton().then {
         $0.setTitle("전체보기", for: .normal)
         $0.tintColor = .white
         $0.setTitleColor(UIColor(hexCode: "9C9C9C"), for: .normal)
@@ -158,7 +162,7 @@ class MainViewController: UIViewController {
         $0.semanticContentAttribute = .forceRightToLeft
     }
     
-    final private lazy var movieCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
+    private lazy var movieCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout().then {
         $0.scrollDirection = .horizontal
         $0.minimumLineSpacing = 10
         $0.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
@@ -171,6 +175,12 @@ class MainViewController: UIViewController {
     
     // MARK: - ViewDidLoad()
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        getBoxOfficeList()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -182,7 +192,8 @@ class MainViewController: UIViewController {
     
     // MARK: - setUpLayout()
     
-    final private func setUpLayout() {
+    private func setUpLayout() {
+        print(contentData)
         view.backgroundColor = .white
         
         view.addSubview(scrollView)
@@ -195,13 +206,12 @@ class MainViewController: UIViewController {
         [
             logoImageView, mirroringButton, profileImageView, segmentCollectionView
         ].forEach { mainPosterView.addSubview($0) }
-        view.addSubview(segmentCollectionView)
     }
     
     
     // MARK: - setUpConstraint()
     
-    final private func setUpConstraint() {
+    private func setUpConstraint() {
         scrollView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
@@ -324,12 +334,38 @@ class MainViewController: UIViewController {
     
     // MARK: - setUpDelegate()
     
-    final private func setUpDelegate() {
+    private func setUpDelegate() {
         [
             segmentCollectionView, contentCollectionView, channelCollectionView, seriesCollectionView, movieCollectionView
         ].forEach {
             $0.delegate = self
             $0.dataSource = self
+        }
+    }
+    
+    
+    // MARK: - getBoxOfficeList()
+    
+    private func getBoxOfficeList() {
+        let provider = MoyaProvider<WeeklyBoxOfficeAPI>()
+        
+        provider.request(.weekly) { [self] result in
+            switch result {
+            case let .success(result):
+                let result = try? result.map(WeeklyResponseModel.self)
+                guard let movieList = result?.boxOfficeResult.weeklyBoxOfficeList else { return }
+                
+                for movie in movieList {
+                    self.contentData.append(Content(image: .mainPoster, name: movie.movieNm))
+                }
+                
+                [
+                    self.contentCollectionView, seriesCollectionView, movieCollectionView
+                ].forEach { $0.reloadData() }
+                
+            case .failure(_):
+                print("오류")
+            }
         }
     }
 }
@@ -342,7 +378,7 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
         if collectionView == channelCollectionView { return channelDummy.count }
         if collectionView == segmentCollectionView { return segmentData.count }
         
-        return contentDummy.count
+        return contentData.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -367,8 +403,8 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDataSour
             return segmentCell!
         }
         
-        contentCell?.contentImageView.image = contentDummy[indexPath.row].image
-        contentCell?.contentLabel.text = contentDummy[indexPath.row].name
+        contentCell?.contentImageView.image = contentData[indexPath.row].image
+        contentCell?.contentLabel.text = contentData[indexPath.row].name
         
         return contentCell!
     }


### PR DESCRIPTION
## 📍 주차별 과제 설명
- Moya 라이브러리 이용해 영화진흥위원회 OpenAPI 하나 이상 연결하기

## 💻 주요 코드 설명
### OpenAPI 연결을 위한 연결 key Security 처리
- 영화진흥위원회 API 연결을 위해서는 key 설정이 필요했습니다.
- 해당 key가 공개되면 안돼서 따로 Security 처리를 위해 class를 구현해 static으로 변수를 선언했습니다.

`Secret.swift`
```Swift
import Foundation


class Secret {
    static let movieAPIkey = SECRET_KEY
}
```

`WeeklyBoxOfficeAPI.swift`
```swift
...
case .weekly:
            let parameter: [String: String] = [
                "key": Secret.movieAPIkey,
...
```
- API의 파라미터를 세팅해주는 과정에서 사용했습니다.

### 영화진흥위원회 주간 박스오피스 API 연결
- [영화진흥위원회](http://www.kobis.or.kr/kobisopenapi/homepg/apiservice/searchServiceInfo.do)의 주간 박스오피스 API를 연결했습니다.
- 아래와 같은 플로우로 연결했습니다.
```
1. WeeklyBoxOfficeAPI 파일에서 TargetType 정의
2. WeeklyResponseModel에서 Response 모델을 정의
3. MainViewController의 getBoxOfficeList() 에서 provider 정의 (1번에서 선언한 TargetType 이용)
4. 3번에서 정의한 provider 이용해 request 전송
```
- 자세한 설명은 아래에서 진행하겠습니다.

### 1. WeeklyBoxOfficeAPI 파일에서 TargetType 정의
```swift
import Foundation

import Moya

enum WeeklyBoxOfficeAPI {
    case weekly
}


extension WeeklyBoxOfficeAPI: TargetType {
    var path: String {
        return "/kobisopenapi/webservice/rest/boxoffice/searchWeeklyBoxOfficeList.json"
    }
    
    var method: Moya.Method {
        return .get
    }
    
    var task: Moya.Task {
        switch self {
        case .weekly:
            let parameter: [String: String] = [
                "key": Secret.movieAPIkey,
                "targetDt": "20240503",
                "weekGb": "0",
                "itemPerPage": "10",
                "multiMovieYn": "",
                "repNationCd": "",
                "wideAreaCd": ""
            ]
            
            return .requestParameters(parameters: parameter, encoding: URLEncoding.queryString)
            
        default:
            return .requestPlain
        }
        
    }
    
    var headers: [String : String]? {
        return ["Content-Type": "application/json"]
    }
    
    var baseURL: URL {
        return URL(string: "http://www.kobis.or.kr")!
    }
}
```
- `WeeklyBoxOfficeAPI`라는 이름의 `enum` 객체를 선언해 `case`를 분리했습니다.
- `TargetType` `extension`을 선언해 request를 위한 초기 세팅을 진행했습니다.
  - 기본 baseURL, path, header, method, task를 세팅했습니다.
- task 부분에서 case를 나누고, 그에 따른 파라미터를 설정한 뒤 리턴했습니다. 

### 2. WeeklyResponseModel에서 Response 모델을 정의
```swift
import Foundation


struct WeeklyResponseModel: Codable {
    let boxOfficeResult: boxOfficeResult
}

struct boxOfficeResult: Codable {
    let boxofficeType, showRange, yearWeekTime: String
    let weeklyBoxOfficeList: [WeeklyBoxOfficeList]
}

struct WeeklyBoxOfficeList: Codable {
    let rnum, rank, rankInten, rankOldAndNew, movieCd, movieNm, openDt, salesAmt,
    salesShare, salesInten, salesChange, salesAcc, audiCnt, audiInten, audiChange, audiAcc,
    scrnCnt, showCnt: String
}
```
- Postman을 이용해 응답값을 테스트하고, json에 따라 응답 모델을 선언했습니다.

### 3. MainViewController의 getBoxOfficeList() 에서 provider 정의 및 request 전송 (1번에서 선언한 TargetType 이용) &
```swift
private func getBoxOfficeList() {
        let provider = MoyaProvider<WeeklyBoxOfficeAPI>()
        
        provider.request(.weekly) { [self] result in
            switch result {
            case let .success(result):
                let result = try? result.map(WeeklyResponseModel.self)
                guard let movieList = result?.boxOfficeResult.weeklyBoxOfficeList else { return }
                
                for movie in movieList {
                    self.contentData.append(Content(image: .mainPoster, name: movie.movieNm))
                }
                
                [
                    self.contentCollectionView, seriesCollectionView, movieCollectionView
                ].forEach { $0.reloadData() }
                
            case .failure(_):
                print("오류")
            }
        }
    }
```
- 1번에서 정의한 `TargetType`을 이용해 `MoyaProvider` 객체를 선언했습니다.
- `provider` 객체를 이용해 `request`를 진행했고, `result` 값을 받아 처리했습니다.
  - 성공할 경우 미리 선언된 `contentData`에 데이터 값을 `Content` 구조체 형식에 맞춰 하나씩 `append`했고, 이후 뷰 업데이트를 위해 `reloadData`를 진행했습니다.

## 📸 스크린샷
https://github.com/NOW-SOPT-iOS-Part/LeeYouJin-assignment/assets/80394340/c54f96a0-024d-4b57-8492-4b9e2ea2d213





